### PR TITLE
Fix sharp/slight left icon name misprint

### DIFF
--- a/src/itinerary_builder.js
+++ b/src/itinerary_builder.js
@@ -52,10 +52,10 @@ module.exports = function (language) {
         icon = 'bear-right';
         break;
       case 'left':
-      case 'slight left':
+      case 'sharp left':
         icon = 'turn-left';
         break
-      case 'sharp left':
+      case 'slight left':
         icon = 'bear-left';
         break;
       case 'uturn':


### PR DESCRIPTION
Some misprint seems to be in sharp/slight left icon name assigning.